### PR TITLE
Consider concurrent encoding when selecting best encoder

### DIFF
--- a/view/index.php
+++ b/view/index.php
@@ -178,7 +178,7 @@ $encoders = Encoder::getAll();
                                             <div class="ellipsis">
                                                 <span class="account-type"><?php echo $value['name']; ?></span>
                                                 <span id="recommended<?php echo $value['id']; ?>" class="label label-success recommended" style="display: none;"><i class="fa fa-check"></i> Recommended</span><br/>
-                                                <span id="label<?php echo $value['id']; ?>" class="label label-danger">Offline</span> <span class="account-amount" id="queuesize<?php echo $value['id']; ?>" >Queue Size 0</span><br/>
+                                                <span id="label<?php echo $value['id']; ?>" class="label label-danger">Offline</span> <span class="account-amount" id="queuesize<?php echo $value['id']; ?>" >Queue Size 0 </span> / <span class="account-amount" id="concurrent<?php echo $value['id']; ?>" >Concurrent 1 </span> <br/>
                                                 <a href="<?php echo $value['siteURL']; ?>" class="account-link"><?php
                                                     $parts = parse_url($value['siteURL']);
                                                     echo $parts["host"];
@@ -294,6 +294,7 @@ $encoders = Encoder::getAll();
                                 }
 
                                 $('#queuesize' + id).text("Queue Size " + response.queue_size);
+                                $('#concurrent' + id).text("Concurrent " + response.concurrent);
                                 $('#maxfilesize' + id).text("Max File Size " + response.file_upload_max_size);
 
                             } else {


### PR DESCRIPTION
This relies on https://github.com/WWBN/AVideo-Encoder/pull/348
to get how many concurent jobs an encoder can perform? The
rcommandation needs to take it into account because queue size = 6
with concurrent = 6 is better thant queue size = 2 with concurrent = 1.